### PR TITLE
Fixes for Pandeia v1.4dev compatibility

### DIFF
--- a/tests/nircam/nircam_sensitivity_lw.py
+++ b/tests/nircam/nircam_sensitivity_lw.py
@@ -1,7 +1,7 @@
 import numpy as np
 import astropy.io.fits as fits
 from verification_tools import calc_limits
-from verification_tools import fudge_throughput as ft
+#from verification_tools import fudge_throughput as ft
 
 configs = [{'filter':'f250m','idt':28.33},
            {'filter':'f277w','idt':12.70},
@@ -18,7 +18,7 @@ configs = [{'filter':'f250m','idt':28.33},
            {'filter':'f460m','idt':73.56},
            {'filter':'f466n','idt':235.43},
            {'filter':'f470n','idt':286.00},
-           {'filter':'f480m','idt':82.12}       
+           {'filter':'f480m','idt':82.12}
        ]
 
 
@@ -54,9 +54,8 @@ strategy = {
             'dithers': [{'x':0.0,'y':0.0}],
             'background_subtraction': False
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=10,nflx=10,skyfacs=2.,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 np.savez('../../outputs/nircam_lw_sensitivity.npz',
     wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'], sat_limits=output['sat_limits'], configs=output['configs'])
-

--- a/tests/nircam/nircam_sensitivity_lw.py
+++ b/tests/nircam/nircam_sensitivity_lw.py
@@ -1,7 +1,6 @@
 import numpy as np
 import astropy.io.fits as fits
 from verification_tools import calc_limits
-#from verification_tools import fudge_throughput as ft
 
 configs = [{'filter':'f250m','idt':28.33},
            {'filter':'f277w','idt':12.70},

--- a/tests/nircam/nircam_sensitivity_wfgrism.py
+++ b/tests/nircam/nircam_sensitivity_wfgrism.py
@@ -1,7 +1,7 @@
 import numpy as np
 import astropy.io.fits as fits
 from verification_tools import calc_limits
-from verification_tools import fudge_throughput as ft
+#from verification_tools import fudge_throughput as ft
 
 configs = [{'aperture':'lw','filter':'f250m','disperser':'grismr','bounds':(2.421,2.581)},
            {'aperture':'lw','filter':'f277w','disperser':'grismr','bounds':(2.421,3.09)},
@@ -15,7 +15,7 @@ configs = [{'aperture':'lw','filter':'f250m','disperser':'grismr','bounds':(2.42
            {'aperture':'lw','filter':'f444w','disperser':'grismr','bounds':(3.929,4.949)},
            {'aperture':'lw','filter':'f460m','disperser':'grismr','bounds':(4.543,4.713)},
            {'aperture':'lw','filter':'f480m','disperser':'grismr','bounds':(4.693,4.921)}]
-     
+
 apertures = np.array([2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5])*0.0648
 idt_fluxes = np.array([1e-2, 1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2])
 skyfacs = [2,2,2,2,2,2,2,2,2,2,2,2]
@@ -39,7 +39,7 @@ strategy = {
             'sky_annulus': [0.16,0.5],
             'background_subtraction': False
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=5,skyfacs=skyfacs,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 

--- a/tests/nircam/nircam_sensitivity_wfgrism.py
+++ b/tests/nircam/nircam_sensitivity_wfgrism.py
@@ -1,7 +1,6 @@
 import numpy as np
 import astropy.io.fits as fits
 from verification_tools import calc_limits
-#from verification_tools import fudge_throughput as ft
 
 configs = [{'aperture':'lw','filter':'f250m','disperser':'grismr','bounds':(2.421,2.581)},
            {'aperture':'lw','filter':'f277w','disperser':'grismr','bounds':(2.421,3.09)},

--- a/tests/wfirstimager/wfirstimager_sensitivity_grism.py
+++ b/tests/wfirstimager/wfirstimager_sensitivity_grism.py
@@ -1,0 +1,36 @@
+import numpy as np
+import astropy.io.fits as fits
+from verification_tools import calc_limits
+#from verification_tools import fudge_throughput as ft
+
+configs = [{'aperture':'grism','filter':'g150','disperser':'grsgrism','bounds':(0.95,1.9)}]
+
+apertures = np.array([2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5,2.5])*0.11
+idt_fluxes = np.array([1e-2, 1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2,1e-2])
+skyfacs = [2,2,2,2,2,2,2,2,2,2,2,2]
+obsmode = {
+           'instrument': 'wfirstimager',
+           'mode': 'grism',
+           'filter': 'g150',
+           'aperture': 'grism',
+           'disperser': 'grsgrism'
+           }
+exp_config = {
+              'subarray': 'full',
+              'readmode': 'deep8',
+              'ngroup': 5,
+              'nint': 1,
+              'nexp': 10
+              }
+strategy = {
+            'method': 'specapphot',
+            'aperture_size': 0.15,
+            'sky_annulus': [0.16,0.5],
+            'background_subtraction': False
+            }
+
+output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=5,skyfacs=skyfacs,
+                                 exp_config=exp_config,strategy=strategy,background='minzodi12')
+
+np.savez('../../outputs/wfirst_wfirstgrism_sensitivity.npz',
+    wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'], sat_limits=output['sat_limits'], configs=output['configs'])

--- a/tests/wfirstimager/wfirstimager_sensitivity_imager.py
+++ b/tests/wfirstimager/wfirstimager_sensitivity_imager.py
@@ -1,0 +1,52 @@
+import numpy as np
+import astropy.io.fits as fits
+from verification_tools import calc_limits
+#from verification_tools import fudge_throughput as ft
+
+configs = [{'filter':'r062','idt':55.33},
+           {'filter':'z087','idt':12.70},
+           {'filter':'y106','idt':22.94},
+           {'filter':'j129','idt':8.55},
+           {'filter':'w146','idt':166.61},
+           {'filter':'h158','idt':19.43},
+           {'filter':'f184','idt':12.83}
+       ]
+
+
+idt_fluxes = np.array([config['idt'] for config in configs])*1e-6
+#wave_centers = np.array([2.5,2.77,3.0,3.22,3.23,3.35,3.56,3.60,4.05,4.10,4.18,4.30,4.44,4.60,4.66,4.70,4.80])
+pixscale = 0.11  # arcsec
+#diameter_flat_to_flat = 6.5 * 1e6 # meters to micron
+#apertures = []
+#for wave_center in wave_centers:
+#    apertures.append(np.max([2.5*pixscale, (1.25 * (wave_center / diameter_flat_to_flat) *
+#                     (180 * 3600 / np.pi))]))
+apertures = np.array([2.5,2.5,2.5,2.5,2.5,2.5,2.5])*pixscale
+
+obsmode = {
+           'instrument': 'wfirstimager',
+           'mode': 'imaging',
+           'filter': 'r062',
+           'aperture': 'any',
+           'disperser': None
+           }
+exp_config = {
+              'subarray': 'full',
+              'readmode': 'deep8',
+              'ngroup': 5,
+              'nint': 1,
+              'nexp': 10
+              }
+strategy = {
+            'method': 'imagingapphot',
+            'aperture_size': 0.5,
+            'sky_annulus': [0.6,3.2],
+            'target': [0.0, 0.0],
+            'dithers': [{'x':0.0,'y':0.0}],
+            'background_subtraction': False
+            }
+
+output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=10,nflx=10,skyfacs=2.,
+                                 exp_config=exp_config,strategy=strategy,background='minzodi12')
+np.savez('../../outputs/wfirstimager_imager_sensitivity.npz',
+    wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'], sat_limits=output['sat_limits'], configs=output['configs'])

--- a/verification_tools/calc_limits.py
+++ b/verification_tools/calc_limits.py
@@ -9,71 +9,71 @@ from astropy.io import fits, ascii
 
 from pandeia.engine.perform_calculation import perform_calculation
 
-def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None, 
-                exp_config=None, exp_configs=None, strategy=None, nflx=10, 
+def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
+                exp_config=None, exp_configs=None, strategy=None, nflx=10,
                 background='minzodi12',skyfacs=None,orders=None,lim_snr=10.0):
 
     """
-    Script to calculate sensitivity limits for point sources using Pandeia. The script calculates a 
-    grid of models by varying the source flux density, yielding a numerical function SNR(F). 
+    Script to calculate sensitivity limits for point sources using Pandeia. The script calculates a
+    grid of models by varying the source flux density, yielding a numerical function SNR(F).
     The sensitivity limit is then calculated by inverting the function SNR(F) => F(SNR=lim_snr). It is possible
-    to calculate the limiting sensitivity for a single Pandeia configuration, or for a list of N configurations, 
-    with some limitations. Most often, the user will probably loop over a list of N configurations, varying a filter, 
-    grating or other parameter. 
+    to calculate the limiting sensitivity for a single Pandeia configuration, or for a list of N configurations,
+    with some limitations. Most often, the user will probably loop over a list of N configurations, varying a filter,
+    grating or other parameter.
 
     Parameters
     ----------
-    configs: list of N dicts 
-        Contains dictionaries containing keyword/value pairs relevant for a Pandeia obsmode. 
-        For a given mode, passed values will be replaced, while others will default. These are the values 
-        of the configuration that are VARIED. For instance, the user might want to loop over different filter values. 
-    apertures: list of N floats 
+    configs: list of N dicts
+        Contains dictionaries containing keyword/value pairs relevant for a Pandeia obsmode.
+        For a given mode, passed values will be replaced, while others will default. These are the values
+        of the configuration that are VARIED. For instance, the user might want to loop over different filter values.
+    apertures: list of N floats
         Extraction apertures for each config.
-    fluxes: List of N floats 
-        Initial guess of limiting flux in mJy      
+    fluxes: List of N floats
+        Initial guess of limiting flux in mJy
     scanfac: float
-        Factor within which to search for the limiting flux. IMPORTANT: It is currently the users 
-        responsibility to check that the limiting flux is contained within fluxes/scanfac -> fluxes*scanfac. 
-        for spectroscopic modes, this should be true for every wavelength.        
+        Factor within which to search for the limiting flux. IMPORTANT: It is currently the users
+        responsibility to check that the limiting flux is contained within fluxes/scanfac -> fluxes*scanfac.
+        for spectroscopic modes, this should be true for every wavelength.
     obsmode: dict
-        These are dictionary keyword/value pairs of a Pandeia obsmode that are NOT varied. Typically, 
-        this would identify the instrument and mode.        
+        These are dictionary keyword/value pairs of a Pandeia obsmode that are NOT varied. Typically,
+        this would identify the instrument and mode.
     exp_config: dict
-        This is a dictionary of non-default values for a Pandeia exposure configuration. 
-        Set EITHER exp_config OR exp_configs.         
-    exp_configs: list of N dicts        
-        The user may want to use a different set of exposure configs for every obsmode config. 
-        In that case use this to pass N different versions.   
+        This is a dictionary of non-default values for a Pandeia exposure configuration.
+        Set EITHER exp_config OR exp_configs.
+    exp_configs: list of N dicts
+        The user may want to use a different set of exposure configs for every obsmode config.
+        In that case use this to pass N different versions.
     strategy: dict
-        A dictionary containing a valid Pandeia strategy. It is currently not possible to change the 
-        strategy for every configuration.         
+        A dictionary containing a valid Pandeia strategy. It is currently not possible to change the
+        strategy for every configuration.
     nflx: Integer
-        Number of flux values in the grid. 10 is a reasonable default if the limit guess is close.         
+        Number of flux values in the grid. 10 is a reasonable default if the limit guess is close.
     background: String
-        Invoke a canned background. There are various option, but most people will want to set this to "minzodi12". 
+        Invoke a canned background. There are various option, but most people will want to set this to "minzodi12".
         It is currently not possible to pass a new background beyond editing this scripts, but but it would not be
-        difficult to implement.         
+        difficult to implement.
     skyfacs: float
-        If the strategy is set to use background subtraction, this sets the size of the sky extraction aperture relative to the 
-        extraction aperture.      
+        If the strategy is set to use background subtraction, this sets the size of the sky extraction aperture relative to the
+        extraction aperture.
     orders: List of N integers
-        This sets the order for each configuration. This is the only strategy parameter that can currently be varied.        
+        This sets the order for each configuration. This is the only strategy parameter that can currently be varied.
     lim_snr: float
-        Limiting signal-to-noise ratio. The standard (and default) is 10.0. 
-    
-                
+        Limiting signal-to-noise ratio. The standard (and default) is 10.0.
+
+
     Returns
     ----------
     Dictionary containing:
         configs: List of the input Pandeia configurations
         strategy:  List of the input Pandeia strategies
         wavelengths: The effective wavelength for imaging modes and wavelength arrays for spectroscopic modes
-        sns: The signal-to-noise ratio for each configuration. This is for debugging purposes. 
+        sns: The signal-to-noise ratio for each configuration. This is for debugging purposes.
         lim_fluxes: The calculated limiting flux densities in mJy.
-        source_rates_per_njy: Detected electron rates for a source of 1 nJy. 
+        source_rates_per_njy: Detected electron rates for a source of 1 nJy.
         sat_limits: The calculated saturation limit
         orders: The input spectral order
-        line_limits: Limiting integrated line flux in W/m^2. 
+        line_limits: Limiting integrated line flux in W/m^2.
 
     """
 
@@ -100,7 +100,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         fnu = (wave_mu**2/c_mu)*flambda
         fnu_Jy = fnu*1e26
         fnu_MJy = fnu_Jy/1e6
-        background = [wave_mu,fnu_MJy+scat_MJy]       
+        background = [wave_mu,fnu_MJy+scat_MJy]
     elif background in ['niriss']:
         syspath = os.path.abspath(os.path.dirname(__file__))
         bg_table = ascii.read(os.path.join(syspath,'inputs/NIRISS_background.txt'))
@@ -114,7 +114,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         bg_table = fits.getdata(os.path.join(syspath,'inputs/minzodi12_12052016.fits'))
         background = [bg_table['wavelength'],bg_table['background']]
 
-    
+
     source = {
         'id': 1,
         'target': True,
@@ -158,7 +158,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
 
         if np.size(exp_configs)>1:
             exp_config = exp_configs[i]
-            
+
         if np.size(skyfacs)>1:
             skyfac = skyfacs[i]
         else:
@@ -168,41 +168,43 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         if orders is not None:
             strategy['order'] = orders[i]
 
+        print(obsmode['mode'])
+
         if skyfacs is None:
             inner_fac = 2.
             outer_fac = 5.
         else:
-            if obsmode['mode'] in ['msa','fixed_slit','lrsslit','lrsslitless','wfgrism','ssgrism','wfss','soss']:
+            if obsmode['mode'] in ['msa','fixed_slit','lrsslit','lrsslitless','wfgrism','ssgrism','wfss','soss','grism']:
                 inner_fac = 1.5
                 outer_fac = inner_fac+skyfac/2.
-            elif obsmode['mode'] in ['ifu','mrs','sw_imaging','lw_imaging','imaging','ami']:
+            elif obsmode['mode'] in ['ifu','mrs','sw_imaging','lw_imaging','imaging','ami','imager']:
                 inner_fac = 2.
                 outer_fac = np.sqrt(skyfac+inner_fac**2.)
 
-        if 'sky_annulus' in strategy.keys():    
+        if 'sky_annulus' in strategy.keys():
             strategy['sky_annulus'] = [aperture*inner_fac,aperture*outer_fac]
-        
+
         for key in config.keys():
-            obsmode[key] = config[key] 
+            obsmode[key] = config[key]
 
         scene = [source]
 
         flx_expansion = np.logspace(np.log10(flux/scanfac),np.log10(flux*scanfac),nflx)
-        
+
         sn_arr = []
 
         for flux in flx_expansion:
-            
+
             source['spectrum']['normalization']['norm_flux'] = flux
-    
+
             input = {
                 'scene': scene,
                 'background': background,
                 'configuration': {'instrument': obsmode,
                 'detector': exp_config},
                 'strategy': strategy
-            }  
-    
+            }
+
             report = perform_calculation(input, dict_report=False)
             bg_pix_rate = np.min(report.bg_pix)
             aperture_source_rate = report.curves['extracted_flux'][1]
@@ -211,30 +213,30 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             fits_dict = report.as_fits()
 
             sn_arr.append(fits_dict['1d']['sn'][0].data['sn'])
-       
+
             wavelength = fits_dict['1d']['sn'][0].data['wavelength']
-            
+
         bsubs = np.isinf(fits_dict['1d']['sn'][0].data['sn'])
 
         sn_arr = np.array(sn_arr)
         lim_flx = np.array([np.interp(lim_snr,sn_arr[:,i],flx_expansion) for i in np.arange(wavelength.size)])
         # Make sure that undefined points remain undefined in the limiting flux
         lim_flx[bsubs] = np.nan
-      
+
         if len(lim_flx)>0:
             lim_flx = lim_flx.flatten()
-    
+
         wavelengths.append(wavelength)
         sns.append(fits_dict['1d']['sn'][0].data['sn'])
         lim_fluxes.append(lim_flx)
         source_rates.append(aperture_source_rate/flux/1e6)
-        
+
         nwaves = np.size(aperture_source_rate)
-        
+
         midpoint = int(nwaves/2)
-        
+
         #The best one at the midpoint. It doesn't really matter what the reference spectrum is here. We
-        #just need one to calculate the rate per mJy for the saturation estimate. 
+        #just need one to calculate the rate per mJy for the saturation estimate.
         source['spectrum']['normalization']['norm_flux'] = lim_flx[midpoint]
 
         input = {
@@ -243,7 +245,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             'configuration': {'instrument': obsmode,
             'detector': exp_config},
             'strategy': strategy
-        }  
+        }
 
         report = perform_calculation(input, dict_report=False)
         fits_dict = report.as_fits()
@@ -253,14 +255,14 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         aperture_total_rate = report.curves['extracted_flux_plus_bg'][1]
         aperture_bg_rate = aperture_total_rate-aperture_source_rate
         fov_source_rate = report.curves['total_flux'][1]
-        
+
         tgroup = report.signal.current_instrument.get_exposure_pars().tgroup
         tframe =  report.signal.current_instrument.get_exposure_pars().tframe
         tfffr = report.signal.current_instrument.get_exposure_pars().tfffr
         det_type = report.signal.current_instrument.get_exposure_pars().det_type
-        
+
         if det_type=='h2rg':
-            mintime = tfffr + 2 * tframe 
+            mintime = tfffr + 2 * tframe
         else:
             mintime = tfffr + 5 * tframe #minimum recommended frames is 5 for MIRI
 
@@ -269,18 +271,18 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             report.bg_pix = np.rot90(report.bg_pix)
             report.signal.rate = np.rot90(report.signal.rate)
 
-        # Spectrum?        
+        # Spectrum?
         if (lim_flx.shape[0]>1) and (report.signal.rate.shape[1]!=lim_flx.shape[0]):
             #slitless modes have excess pixels on each side - excess should always be an odd integer
             excess = (report.signal.rate.shape[1]-lim_flx.shape[0])-1
         else:
             excess=0
-            
+
         if excess==0:
             fullwell_minus_bg = (report.signal.det_pars['fullwell']-mintime*report.bg_pix)
             rate_per_mjy = report.signal.rate/lim_flx[midpoint]
             bg_pix_rate_min = np.min(report.bg_pix,0)
-            bg_pix_rate_max = np.max(report.bg_pix,0) 
+            bg_pix_rate_max = np.max(report.bg_pix,0)
         else:
             bg_pix_rate_min = np.min(report.bg_pix[:,int(excess/2):-int(excess/2)])
             bg_pix_rate_max = np.max(report.bg_pix[:,int(excess/2):-int(excess/2)])
@@ -289,7 +291,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
 
         sat_limit_detector = fullwell_minus_bg/mintime/np.abs(rate_per_mjy) #units of mJy
 
-        # Calculate line sensitivities, assuming unresolved lines. 
+        # Calculate line sensitivities, assuming unresolved lines.
         if lim_flx.shape[0]>1:
             sat_limit = np.min(sat_limit_detector,0)
             r = report.signal.current_instrument.get_resolving_power(wavelength)
@@ -299,15 +301,15 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             freqs = 2.99792458e14/wavelength
             px_width_hz = np.abs(freqs-np.roll(freqs,1))
             px_width_hz[:1] = px_width_hz[1]
-            
-            line_width_px = wavelength/r/px_width_micron  
+
+            line_width_px = wavelength/r/px_width_micron
             line_limit = lim_flx*1e-3*1e-26 * px_width_hz * line_width_px / np.sqrt(line_width_px)
             line_limits.append(line_limit)
         else:
             sat_limit = np.min(sat_limit_detector)
-            
+
         sat_limits.append(sat_limit)
-        
+
         print('Configuration:', config)
         print('Exposure Time:', '{:7.2f}'.format(rep_dict['scalar']['exposure_time']))
         print('Total Exposure Time:', '{:7.2f}'.format(rep_dict['scalar']['total_exposure_time']))
@@ -323,6 +325,6 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         print('Limiting flux:', '{:7.2e}'.format(np.min(lim_flx)),'mJy')
         print('SNR:', '{:7.2f}'.format(fits_dict['1d']['sn'][0].data['sn'][midpoint]))
         print('Reference wavelength:', '{:7.2e}'.format(fits_dict['1d']['sn'][0].data['wavelength'][midpoint]))
-                
+
     return {'configs':configs,'strategy':strategy, 'wavelengths':wavelengths,'sns':sns,'lim_fluxes':lim_fluxes,
             'source_rates_per_njy':source_rates, 'sat_limits':sat_limits, 'orders':orders, 'line_limits':line_limits}

--- a/verification_tools/calc_limits.py
+++ b/verification_tools/calc_limits.py
@@ -21,6 +21,9 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
     with some limitations. Most often, the user will probably loop over a list of N configurations, varying a filter,
     grating or other parameter.
 
+    This will only work with a pandeia where the results object has a bg_pix attribute
+    for every strategy (not v1.3, where it's not present when calculating any IFU strategies)
+
     Parameters
     ----------
     configs: list of N dicts
@@ -113,6 +116,8 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         syspath = os.path.abspath(os.path.dirname(__file__))
         bg_table = fits.getdata(os.path.join(syspath,'inputs/minzodi12_12052016.fits'))
         background = [bg_table['wavelength'],bg_table['background']]
+    else:
+        raise ValueError('Unrecognized background {}'.format(background))
 
 
     source = {
@@ -178,6 +183,8 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             elif obsmode['mode'] in ['ifu','mrs','sw_imaging','lw_imaging','imaging','ami','imager']:
                 inner_fac = 2.
                 outer_fac = np.sqrt(skyfac+inner_fac**2.)
+            else:
+                raise ValueError('Unrecognized mode {}'.format(obsmode['mode'])
 
         if 'sky_annulus' in strategy.keys():
             strategy['sky_annulus'] = [aperture*inner_fac,aperture*outer_fac]

--- a/verification_tools/calc_limits.py
+++ b/verification_tools/calc_limits.py
@@ -168,8 +168,6 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         if orders is not None:
             strategy['order'] = orders[i]
 
-        print(obsmode['mode'])
-
         if skyfacs is None:
             inner_fac = 2.
             outer_fac = 5.

--- a/verification_tools/calc_limits_extended.py
+++ b/verification_tools/calc_limits_extended.py
@@ -9,71 +9,71 @@ from astropy.io import fits, ascii
 
 from pandeia.engine.perform_calculation import perform_calculation
 
-def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None, 
-                exp_config=None, exp_configs=None, strategy=None, nflx=10, 
+def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
+                exp_config=None, exp_configs=None, strategy=None, nflx=10,
                 background='miri',skyfacs=None,orders=None,lim_snr=10.0):
 
     """
-    Script to calculate sensitivity limits for extended sources using Pandeia. The script calculates a 
-    grid of models by varying the source flux density, yielding a numerical function SNR(F). 
+    Script to calculate sensitivity limits for extended sources using Pandeia. The script calculates a
+    grid of models by varying the source flux density, yielding a numerical function SNR(F).
     The sensitivity limit is then calculated by inverting the function SNR(F) => F(SNR=lim_snr). It is possible
-    to calculate the limiting sensitivity for a single Pandeia configuration, or for a list of N configurations, 
-    with some limitations. Most often, the user will probably loop over a list of N configurations, varying a filter, 
-    grating or other parameter. 
+    to calculate the limiting sensitivity for a single Pandeia configuration, or for a list of N configurations,
+    with some limitations. Most often, the user will probably loop over a list of N configurations, varying a filter,
+    grating or other parameter.
 
     Parameters
     ----------
-    configs: list of N dicts 
-        Contains dictionaries containing keyword/value pairs relevant for a Pandeia obsmode. 
-        For a given mode, passed values will be replaced, while others will default. These are the values 
-        of the configuration that are VARIED. For instance, the user might want to loop over different filter values. 
-    apertures: list of N floats 
+    configs: list of N dicts
+        Contains dictionaries containing keyword/value pairs relevant for a Pandeia obsmode.
+        For a given mode, passed values will be replaced, while others will default. These are the values
+        of the configuration that are VARIED. For instance, the user might want to loop over different filter values.
+    apertures: list of N floats
         Extraction apertures for each config.
-    fluxes: List of N floats 
-        Initial guess of limiting flux in mJy      
+    fluxes: List of N floats
+        Initial guess of limiting flux in mJy
     scanfac: float
-        Factor within which to search for the limiting flux. IMPORTANT: It is currently the users 
-        responsibility to check that the limiting flux is contained within fluxes/scanfac -> fluxes*scanfac. 
-        for spectroscopic modes, this should be true for every wavelength.        
+        Factor within which to search for the limiting flux. IMPORTANT: It is currently the users
+        responsibility to check that the limiting flux is contained within fluxes/scanfac -> fluxes*scanfac.
+        for spectroscopic modes, this should be true for every wavelength.
     obsmode: dict
-        These are dictionary keyword/value pairs of a Pandeia obsmode that are NOT varied. Typically, 
-        this would identify the instrument and mode.        
+        These are dictionary keyword/value pairs of a Pandeia obsmode that are NOT varied. Typically,
+        this would identify the instrument and mode.
     exp_config: dict
-        This is a dictionary of non-default values for a Pandeia exposure configuration. 
-        Set EITHER exp_config OR exp_configs.         
-    exp_configs: list of N dicts        
-        The user may want to use a different set of exposure configs for every obsmode config. 
-        In that case use this to pass N different versions.   
+        This is a dictionary of non-default values for a Pandeia exposure configuration.
+        Set EITHER exp_config OR exp_configs.
+    exp_configs: list of N dicts
+        The user may want to use a different set of exposure configs for every obsmode config.
+        In that case use this to pass N different versions.
     strategy: dict
-        A dictionary containing a valid Pandeia strategy. It is currently not possible to change the 
-        strategy for every configuration.         
+        A dictionary containing a valid Pandeia strategy. It is currently not possible to change the
+        strategy for every configuration.
     nflx: Integer
-        Number of flux values in the grid. 10 is a reasonable default if the limit guess is close.         
+        Number of flux values in the grid. 10 is a reasonable default if the limit guess is close.
     background: String
-        Invoke a canned background. There are various option, but most people will want to set this to "minzodi12". 
+        Invoke a canned background. There are various option, but most people will want to set this to "minzodi12".
         It is currently not possible to pass a new background beyond editing this scripts, but but it would not be
-        difficult to implement.         
+        difficult to implement.
     skyfacs: float
-        If the strategy is set to use background subtraction, this sets the size of the sky extraction aperture relative to the 
-        extraction aperture.      
+        If the strategy is set to use background subtraction, this sets the size of the sky extraction aperture relative to the
+        extraction aperture.
     orders: List of N integers
-        This sets the order for each configuration. This is the only strategy parameter that can currently be varied.        
+        This sets the order for each configuration. This is the only strategy parameter that can currently be varied.
     lim_snr: float
-        Limiting signal-to-noise ratio. The standard (and default) is 10.0. 
-    
-                
+        Limiting signal-to-noise ratio. The standard (and default) is 10.0.
+
+
     Returns
     ----------
     Dictionary containing:
         configs: List of the input Pandeia configurations
         strategy:  List of the input Pandeia strategies
         wavelengths: The effective wavelength for imaging modes and wavelength arrays for spectroscopic modes
-        sns: The signal-to-noise ratio for each configuration. This is for debugging purposes. 
+        sns: The signal-to-noise ratio for each configuration. This is for debugging purposes.
         lim_fluxes: The calculated limiting flux densities in mJy/extraction aperture size.
-        source_rates_per_njy: Detected electron rates for a source of 1 nJy. 
+        source_rates_per_njy: Detected electron rates for a source of 1 nJy.
         sat_limits: The calculated saturation limit
         orders: The input spectral order
-        line_limits: Limiting integrated line flux in W/m^2/extraction aperture size. 
+        line_limits: Limiting integrated line flux in W/m^2/extraction aperture size.
 
     """
 
@@ -100,7 +100,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         fnu = (wave_mu**2/c_mu)*flambda
         fnu_Jy = fnu*1e26
         fnu_MJy = fnu_Jy/1e6
-        background = [wave_mu,fnu_MJy+scat_MJy]       
+        background = [wave_mu,fnu_MJy+scat_MJy]
     elif background in ['niriss']:
         syspath = os.path.abspath(os.path.dirname(__file__))
         bg_table = ascii.read(os.path.join(syspath,'inputs/NIRISS_background.txt'))
@@ -114,7 +114,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         bg_table = fits.getdata(os.path.join(syspath,'inputs/minzodi12_12052016.fits'))
         background = [bg_table['wavelength'],bg_table['background']]
 
-    
+
     source = {
         'id': 1,
         'target': True,
@@ -161,7 +161,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
 
         if np.size(exp_configs)>1:
             exp_config = exp_configs[i]
-            
+
         if np.size(skyfacs)>1:
             skyfac = skyfacs[i]
         else:
@@ -182,30 +182,30 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
                 inner_fac = 2.
                 outer_fac = np.sqrt(skyfac+inner_fac**2.)
 
-        if 'sky_annulus' in strategy.keys():    
+        if 'sky_annulus' in strategy.keys():
             strategy['sky_annulus'] = [aperture*inner_fac,aperture*outer_fac]
-        
+
         for key in config.keys():
-            obsmode[key] = config[key] 
+            obsmode[key] = config[key]
 
         scene = [source]
 
         flx_expansion = np.logspace(np.log10(flux/scanfac),np.log10(flux*scanfac),nflx)
-        
+
         sn_arr = []
 
         for flux in flx_expansion:
-            
+
             source['spectrum']['normalization']['norm_flux'] = flux
-    
+
             input = {
                 'scene': scene,
                 'background': background,
                 'configuration': {'instrument': obsmode,
                 'detector': exp_config},
                 'strategy': strategy
-            }  
-    
+            }
+
             report = perform_calculation(input, dict_report=False)
             bg_pix_rate = np.min(report.bg_pix)
             aperture_source_rate = report.curves['extracted_flux'][1]
@@ -214,30 +214,30 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             fits_dict = report.as_fits()
 
             sn_arr.append(fits_dict['1d']['sn'][0].data['sn'])
-       
+
             wavelength = fits_dict['1d']['sn'][0].data['wavelength']
-            
+
         bsubs = np.isinf(fits_dict['1d']['sn'][0].data['sn'])
 
         sn_arr = np.array(sn_arr)
         lim_flx = np.array([np.interp(lim_snr,sn_arr[:,i],flx_expansion) for i in np.arange(wavelength.size)])
         # Make sure that undefined points remain undefined in the limiting flux
         lim_flx[bsubs] = np.nan
-      
+
         if len(lim_flx)>0:
             lim_flx = lim_flx.flatten()
-    
+
         wavelengths.append(wavelength)
         sns.append(fits_dict['1d']['sn'][0].data['sn'])
         lim_fluxes.append(lim_flx)
         source_rates.append(aperture_source_rate/flux/1e6)
-        
+
         nwaves = np.size(aperture_source_rate)
-        
+
         midpoint = int(nwaves/2)
-        
+
         #The best one at the midpoint. It doesn't really matter what the reference spectrum is here. We
-        #just need one to calculate the rate per mJy for the saturation estimate. 
+        #just need one to calculate the rate per mJy for the saturation estimate.
         source['spectrum']['normalization']['norm_flux'] = lim_flx[midpoint]
 
         input = {
@@ -246,25 +246,26 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             'configuration': {'instrument': obsmode,
             'detector': exp_config},
             'strategy': strategy
-        }  
+        }
 
         report = perform_calculation(input, dict_report=False)
         fits_dict = report.as_fits()
+        res_dict = report.as_dict()
 
         aperture_source_rate = report.curves['extracted_flux'][1]
         aperture_total_rate = report.curves['extracted_flux_plus_bg'][1]
         aperture_bg_rate = aperture_total_rate-aperture_source_rate
         fov_source_rate = report.curves['total_flux'][1]
-        
+
         tgroup = report.signal.current_instrument.get_exposure_pars().tgroup
         tframe =  report.signal.current_instrument.get_exposure_pars().tframe
         tfffr = report.signal.current_instrument.get_exposure_pars().tfffr
         det_type = report.signal.current_instrument.get_exposure_pars().det_type
-        
+
         #nprerej =  report.signal.current_instrument.get_exposure_pars().nprerej
 
         if det_type=='h2rg':
-            mintime = tfffr + 2 * tframe 
+            mintime = tfffr + 2 * tframe
         else:
             mintime = tfffr + 5 * tframe #minimum recommended frames is 5 for MIRI
 
@@ -273,18 +274,18 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             report.bg_pix = np.rot90(report.bg_pix)
             report.signal.rate = np.rot90(report.signal.rate)
 
-        # Spectrum?        
+        # Spectrum?
         if (lim_flx.shape[0]>1) and (report.signal.rate.shape[1]!=lim_flx.shape[0]):
             #slitless modes have excess pixels on each side - excess should always be an odd integer
             excess = (report.signal.rate.shape[1]-lim_flx.shape[0])-1
         else:
             excess=0
-            
+
         if excess==0:
             fullwell_minus_bg = (report.signal.det_pars['fullwell']-mintime*report.bg_pix)
             rate_per_mjy = report.signal.rate/lim_flx[midpoint]
             bg_pix_rate_min = np.min(report.bg_pix,0)
-            bg_pix_rate_max = np.max(report.bg_pix,0) 
+            bg_pix_rate_max = np.max(report.bg_pix,0)
         else:
             bg_pix_rate_min = np.min(report.bg_pix[:,int(excess/2):-int(excess/2)])
             bg_pix_rate_max = np.max(report.bg_pix[:,int(excess/2):-int(excess/2)])
@@ -293,7 +294,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
 
         sat_limit_detector = fullwell_minus_bg/mintime/np.abs(rate_per_mjy) #units of mJy
 
-        # Calculate line sensitivities, assuming unresolved lines. 
+        # Calculate line sensitivities, assuming unresolved lines.
         if lim_flx.shape[0]>1:
             sat_limit = np.min(sat_limit_detector,0)
             r = report.signal.current_instrument.get_resolving_power(wavelength)
@@ -303,18 +304,18 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             freqs = 2.99792458e14/wavelength
             px_width_hz = np.abs(freqs-np.roll(freqs,1))
             px_width_hz[:1] = px_width_hz[1]
-            
-            line_width_px = wavelength/r/px_width_micron  
+
+            line_width_px = wavelength/r/px_width_micron
             line_limit = lim_flx*1e-3*1e-26 * px_width_hz * line_width_px / np.sqrt(line_width_px)
             line_limits.append(line_limit)
         else:
             sat_limit = np.min(sat_limit_detector)
 
         sat_limits.append(sat_limit)
-        
+
         print('Configuration:', config)
-        print('Exposure Time:', '{:7.2f}'.format(fits_dict['scalar']['exposure_time']))
-        print('Total Exposure Time:', '{:7.2f}'.format(fits_dict['scalar']['total_exposure_time']))
+        print('Exposure Time:', '{:7.2f}'.format(res_dict['scalar']['exposure_time']))
+        print('Total Exposure Time:', '{:7.2f}'.format(res_dict['scalar']['total_exposure_time']))
         print('Extracted flux/nJy:', aperture_source_rate[midpoint]/lim_flx[midpoint]/1e6)
         print('Saturation limit [mJy]', '{:7.2f}'.format(np.min(sat_limit)))
         print('Extracted source in e-/s:', '{:7.2f}'.format(aperture_source_rate[midpoint]))
@@ -327,6 +328,6 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         print('Limiting flux:', '{:7.2e}'.format(np.min(lim_flx)),'mJy')
         print('SNR:', '{:7.2f}'.format(fits_dict['1d']['sn'][0].data['sn'][midpoint]))
         print('Reference wavelength:', '{:7.2e}'.format(fits_dict['1d']['sn'][0].data['wavelength'][midpoint]))
-                
+
     return {'configs':configs,'strategy':strategy, 'wavelengths':wavelengths,'sns':sns,'lim_fluxes':lim_fluxes,
             'source_rates_per_njy':source_rates, 'sat_limits':sat_limits, 'orders':orders, 'line_limits':line_limits}

--- a/verification_tools/plot_pce.py
+++ b/verification_tools/plot_pce.py
@@ -6,8 +6,8 @@ from matplotlib.ticker import MultipleLocator, FormatStrFormatter, ScalarFormatt
 from get_pce import *
 
 """
-Method to plot the system throughput of a Pandeia instrument/mode/element combination. 
-The arguments use the Pandeia naming conventions. 
+Method to plot the system throughput of a Pandeia instrument/mode/element combination.
+The arguments use the Pandeia naming conventions.
 
 Arguments:
 ---------
@@ -18,37 +18,39 @@ mode: string
 
 Keywords:
 --------
+config: list
+    List of dictionaries of instrument configurations to be extracted and plotted.
 outfile: string
-    Name of the plot file. As usual with matplotlib, the surname defines the image format. 
+    Name of the plot file. As usual with matplotlib, the surname defines the image format.
 wrange: tuple
-    Wavelength range to be plotted. 
+    Wavelength range to be plotted.
 
 """
 def plot_pce(instrument,mode,configs=None,outfile='plot.pdf',wrange=(0.5,5.5),yrange=None,
              label_types=['filter'],logwave=False, filetype='png',comparisons=None, scale_pce=None):
-    
+
     # create figure, assign size
     f,ax = plt.subplots(1,sharex=True,sharey=True)
     f.set_size_inches(11.5,4.5)
 
     # set up colors
-    spectral = cm = plt.get_cmap('spectral') 
+    spectral = cm = plt.get_cmap('Spectral')
     cNorm  = colors.Normalize(vmin=wrange[0], vmax=wrange[1])
     scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=spectral)
 
     # set up minor tick marks
     XminorLocator = MultipleLocator(0.1)
-    YminorLocator = MultipleLocator(0.1)    
-    
+    YminorLocator = MultipleLocator(0.1)
+
     for config in configs:
         wave,pce = get_pce(instrument,mode,config)
         if scale_pce is not None:
             pce *= np.interp(wave,scale_pce['wave'],scale_pce['throughput'])
-            
+
         name = ''
         for label in label_types:
             name=name+config[label]+'\n'
-        
+
         # find the midpoint of the area with the transmission > 50%
         # put the filter label in that location
         maxthrough = np.max(pce)
@@ -59,7 +61,7 @@ def plot_pce(instrument,mode,configs=None,outfile='plot.pdf',wrange=(0.5,5.5),yr
         ax.fill_between(wave,0,pce,color=colorVal,alpha=0.5)
         ax.text(midpt,maxthrough*1.1,
                 name.upper(),color='black',fontsize=10,ha='center')
-        
+
     # Use a logarithmic x-axis?
     if logwave:
         ax.set_xscale('log')
@@ -68,12 +70,12 @@ def plot_pce(instrument,mode,configs=None,outfile='plot.pdf',wrange=(0.5,5.5),yr
     # limit the number of y-ticks
     ax.set_yticks([0, 0.5, 1])
     ax.yaxis.set_minor_locator(YminorLocator)
-    
+
     # x range and ticks
     ax.set_xlim(wrange[0],wrange[1])
     ax.set_xticks(np.linspace(wrange[0],wrange[1],5))
     ax.xaxis.set_minor_locator(XminorLocator)
-    
+
     if yrange is not None:
         ax.set_ylim(yrange[0],yrange[1])
         ax.set_yticks(np.linspace(yrange[0],yrange[1],5))
@@ -91,8 +93,7 @@ def plot_pce(instrument,mode,configs=None,outfile='plot.pdf',wrange=(0.5,5.5),yr
             midpt = np.median(wave[upthrough])
             colorVal = scalarMap.to_rgba(np.mean(wave[upthrough]))
             ax.plot(comparison[0],comparison[1],linestyle='--',color=colorVal)
-        
+
     plt.tight_layout()
-    
+
     f.savefig(outfile+'.'+filetype,clobber=True)
-        

--- a/verification_tools/plot_sensitivity.py
+++ b/verification_tools/plot_sensitivity.py
@@ -1,0 +1,112 @@
+"""
+Properties that can be read out of plot_sensitivity:
+'wavelengths', 'sns', 'lim_fluxes', 'sat_limits'
+'line_limits' is also available for miri lrs and mrs
+"""
+
+import sys
+import glob
+import numpy as np
+from matplotlib import pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.cm as cmx
+from matplotlib.ticker import StrMethodFormatter
+
+
+if len(sys.argv) > 1:
+    prop = sys.argv[1]
+else:
+    print('Run this from the outputs folder.')
+    print('Calling sequence: ')
+    print('    python plot_sensitivity.py <property> <insnameA,modename1...> <insnameB,modename2...>')
+    print('where <property> is sat_limits, lim_fluxes, or sns, and the instruments and modes are JWST ETC names')
+    print('Or to get everything: ')
+    print('    python plot_sensitivity.py <property>')
+    print('Output is a .png file in the directory you\'re running this from.')
+    raise ValueError("Need to specify the property argument.")
+if len(sys.argv) > 2:
+    insnames = sys.argv[2:]
+else:
+    insnames = ['miri,imaging,lrs,mrs', 'nircam,lw,sw', 'niriss,imaging,ami,soss,wfss', 'nirspec,fs,ifu,msa']
+
+fig = plt.figure(figsize=(18,10))
+ax = fig.add_subplot(111)
+bbox_props = dict(boxstyle="round", fc="w", ec="0.5", alpha=0.7)
+
+for instruments in insnames:
+    instrument = instruments.split(',')[0]
+    if instrument == "miri":
+        # set up colors
+        spectral = cm = plt.get_cmap('gist_heat_r')
+        cNorm  = colors.Normalize(vmin=4.0, vmax=30)
+        scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=spectral)
+        ax.plot(-1e-20,-1e-20,label='MIRI')
+    elif instrument == "nircam":
+        # set up colors
+        spectral = cm = plt.get_cmap('OrRd')
+        cNorm  = colors.Normalize(vmin=0.6, vmax=5.4)
+        scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=spectral)
+        ax.plot(-1e-20,-1e-20,label='NIRCam')
+    elif instrument == "niriss":
+        # set up colors
+        spectral = cm = plt.get_cmap('BuPu')
+        cNorm  = colors.Normalize(vmin=0.7, vmax=5.4)
+        scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=spectral)
+        ax.plot(-1e-20,-1e-20,label='NIRISS')
+    elif instrument == "nirspec":
+        # set up colors
+        spectral = cm = plt.get_cmap('YlGn')
+        cNorm  = colors.Normalize(vmin=0.7, vmax=5.4)
+        scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=spectral)
+        ax.plot(-1e-20,-1e-20,label='NIRSpec')
+    elif instrument == "wfirstimager":
+        # set up colors
+        spectral = cm = plt.get_cmap('Spectral_r')
+        cNorm  = colors.Normalize(vmin=0.4, vmax=2)
+        scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=spectral)
+        ax.plot(-1e-20,-1e-20,label='WFI')
+    if prop == 'lim_fluxes':
+        ylabel = 'Flux Density (S/N = 10 in 10000s) (microJy)'
+        mult = 1e3
+        ylim = (1e-2,1e5)
+        yscale = 'log'
+    elif prop == 'sat_limits':
+        ylabel = 'Saturation Limit (Jy)'
+        mult = 1e-3
+        ylim = (1e-4,1e3)
+        yscale = 'log'
+    elif prop == 'sns':
+        ylabel = 'Signal to Noise Ratio'
+        mult = 1
+        ylim = (3,3000)
+        yscale = 'log'
+    else:
+        mult = 1
+        ylabel = 'line_limits'
+        ylim = (1e-23,1e-18)
+        yscale = 'log'
+
+    for mode in instruments.split(',')[1:]:
+        data = np.load('{}_{}_sensitivity.npz'.format(instrument,mode))
+        for x,keys in enumerate(data['configs']):
+            colorVal = scalarMap.to_rgba(np.mean(data['wavelengths'][x]))
+            if len(data['wavelengths'][x]) == 1:
+                ax.scatter(data['wavelengths'][x],data[prop][x]*mult,label=data['configs'][x].values()[0], color=colorVal)
+                ax.text(np.mean(data['wavelengths'][x]), (np.mean(data[prop][x])+(np.max(data[prop][x])/4.))*mult, data['configs'][x].values()[0], ha="center", va="bottom", bbox=bbox_props)
+            else:
+                vals = data[prop][x]
+                vals[np.where(vals > 5e5)] = np.nan
+                ax.plot(data['wavelengths'][x],vals*mult,label=data['configs'][x].values()[0], color=colorVal)
+                ax.text(np.mean(data['wavelengths'][x]), np.nanmean(vals)*mult, data['configs'][x].values()[0], ha="center", va="bottom", bbox=bbox_props)
+        data.close()
+ax.set_xlabel('Wavelength (microns)')
+ax.set_ylabel(ylabel)
+ax.set_ylim(ylim)
+ax.set_xscale('log')
+ax.set_yscale(yscale)
+ax.set_title(prop)
+ax.xaxis.set_major_formatter(StrMethodFormatter('{x:g}'))
+#ax.yaxis.set_major_formatter(StrMethodFormatter('{x:g}'))
+plt.tight_layout()
+
+plt.savefig('{}.png'.format(prop))


### PR DESCRIPTION
This PR:
* Disables the fudge_throughput import
* Adds preliminary WFIRSTImager Imager and WFIRSTImager Grism modes
* Moves the source of the scalar values from the fits report dictionary to the regular report dictionary
* My editor cleaned up a ton of whitespace.
* Adds a plotting tool (non-fancy Matplotlib version)

This won't work on the Pandeia v1.3 release because there is no bg_pix attribute available in the Report object for IFU modes; it should/will work with Pandeia master and future development versions of Pandeia v1.4