### PR TITLE
[WIP] JETC-266: Change readmode to readout_pattern (Verification)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pandeia_verification',
-      version='1.4',
+      version='1.5dev',
       description='Pandeia verification tools',
       author='Klaus Pontoppidan',
       author_email='pontoppi@stsci.edu',
@@ -9,4 +9,3 @@ setup(name='pandeia_verification',
       packages=find_packages(),
       package_data={'verification_tools': ['inputs/*.fits','inputs/*.txt','inputs/*.tab', 'tests/niriss/*.py', 'tests/nircam/*.py', 'tests/miri/*.py', 'tests/nirspec/*.py']}
       )
-

--- a/tests/miri/miri_sensitivity_imaging.py
+++ b/tests/miri/miri_sensitivity_imaging.py
@@ -14,67 +14,67 @@ configs = [{'filter':'f560w'},
 
 exp_configs = [{
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 106,
                 'nint': 2,
                 'nexp': 17
                },
                {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 106,
                 'nint': 2,
                 'nexp':17
                },
                {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 106,
                  'nint': 2,
                  'nexp': 17
                 },
                 {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 106,
                 'nint': 2,
                 'nexp': 17
                 },
                 {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 106,
                  'nint': 2,
                  'nexp': 17
                 },
                {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 22,
                 'nint': 4,
                 'nexp': 41
                 },
                 {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 22,
                  'nint': 4,
                  'nexp': 41
                 },
                 {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 12,
                 'nint': 15,
                 'nexp': 20
                 },
                 {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 12,
                  'nint': 15,
                  'nexp': 20
-                }                
+                }
                ]
 
 apertures = 0.42*np.array([5.6,7.7,10.,11.3,12.8,15.,18.,21.,25.5])/10.
@@ -89,7 +89,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'fast',
+              'readout_pattern': 'fast',
               'ngroup': 81,
               'nint': 40,
               'nexp': 1
@@ -102,7 +102,7 @@ strategy = {
             'dithers': [{'x':0.0,'y':0.0}],
             'background_subtraction': False
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=5,skyfacs=1.,
                                  exp_configs=exp_configs,strategy=strategy,background='minzodi12')
 

--- a/tests/miri/miri_sensitivity_imaging_extended.py
+++ b/tests/miri/miri_sensitivity_imaging_extended.py
@@ -14,67 +14,67 @@ configs = [{'filter':'f560w'},
 
 exp_configs = [{
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 106,
                 'nint': 2,
                 'nexp': 17
                },
                {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 106,
                 'nint': 2,
                 'nexp':17
                },
                {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 106,
                  'nint': 2,
                  'nexp': 17
                 },
                 {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 106,
                 'nint': 2,
                 'nexp': 17
                 },
                 {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 106,
                  'nint': 2,
                  'nexp': 17
                 },
                {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 22,
                 'nint': 4,
                 'nexp': 41
                 },
                 {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 22,
                  'nint': 4,
                  'nexp': 41
                 },
                 {
                 'subarray': 'full',
-                'readmode': 'fast',
+                'readout_pattern': 'fast',
                 'ngroup': 12,
                 'nint': 15,
                 'nexp': 20
                 },
                 {
                  'subarray': 'full',
-                 'readmode': 'fast',
+                 'readout_pattern': 'fast',
                  'ngroup': 12,
                  'nint': 15,
                  'nexp': 20
-                }                
+                }
                ]
 
 #apertures = 0.42*np.array([5.6,7.7,10.,11.3,12.8,15.,18.,21.,25.5])/10.
@@ -90,7 +90,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'fast',
+              'readout_pattern': 'fast',
               'ngroup': 81,
               'nint': 40,
               'nexp': 1
@@ -103,7 +103,7 @@ strategy = {
             'dithers': [{'x':0.0,'y':0.0}],
             'background_subtraction': False
             }
-    
+
 output = calc_limits_extended.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=5,skyfacs=1.,
                                  exp_configs=exp_configs,strategy=strategy,background='minzodi12')
 

--- a/tests/miri/miri_sensitivity_lrs.py
+++ b/tests/miri/miri_sensitivity_lrs.py
@@ -16,7 +16,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'fast',
+              'readout_pattern': 'fast',
               'ngroup': 180,
               'nint': 1,
               'nexp': 20
@@ -28,7 +28,7 @@ strategy = {
             'background_subtraction': False
             }
 
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=100,nflx=20,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 

--- a/tests/miri/miri_sensitivity_mrs.py
+++ b/tests/miri/miri_sensitivity_mrs.py
@@ -26,7 +26,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'fast',
+              'readout_pattern': 'fast',
               'ngroup': 99,
               'nint': 18,
               'nexp': 1
@@ -36,10 +36,10 @@ strategy = {
             'aperture_size': 1.1#,
             #'dithers': [{'x':0,'y':0},{'x':1,'y':1}]
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=15,skyfacs=1.05,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 
 np.savez('../../outputs/miri_mrs_sensitivity.npz',
-    wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'], 
+    wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'],
     sat_limits=output['sat_limits'], configs=output['configs'], line_limits=output['line_limits'])

--- a/tests/miri/miri_sensitivity_mrs_extended.py
+++ b/tests/miri/miri_sensitivity_mrs_extended.py
@@ -27,7 +27,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'fast',
+              'readout_pattern': 'fast',
               'ngroup': 99,
               'nint': 1,
               'nexp': 18
@@ -37,10 +37,10 @@ strategy = {
             'background_subtraction': False,
             'dithers': [{'x':-1,'y':-1},{'x':1,'y':1}]
             }
-    
+
 output = calc_limits_extended.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=15,skyfacs=1.05,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12',nflx=3)
 
 np.savez('../../outputs/miri_mrs_sensitivity_extended.npz',
-    wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'], 
+    wavelengths=output['wavelengths'], sns=output['sns'], lim_fluxes=output['lim_fluxes'],
     sat_limits=output['sat_limits'], configs=output['configs'], line_limits=output['line_limits'])

--- a/tests/nircam/nircam_sensitivity_lw.py
+++ b/tests/nircam/nircam_sensitivity_lw.py
@@ -40,7 +40,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'deep8',
+              'readout_pattern': 'deep8',
               'ngroup': 5,
               'nint': 1,
               'nexp': 10

--- a/tests/nircam/nircam_sensitivity_sw.py
+++ b/tests/nircam/nircam_sensitivity_sw.py
@@ -27,7 +27,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'deep8',
+              'readout_pattern': 'deep8',
               'ngroup': 5,
               'nint': 1,
               'nexp': 10

--- a/tests/nircam/nircam_sensitivity_wfgrism.py
+++ b/tests/nircam/nircam_sensitivity_wfgrism.py
@@ -27,7 +27,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'deep8',
+              'readout_pattern': 'deep8',
               'ngroup': 5,
               'nint': 1,
               'nexp': 10

--- a/tests/niriss/niriss_sensitivity_ami.py
+++ b/tests/niriss/niriss_sensitivity_ami.py
@@ -21,7 +21,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'sub80',
-              'readmode': 'nisrapid',
+              'readout_pattern': 'nisrapid',
               'ngroup': 133,
               'nint': 10,
               'nexp': 100

--- a/tests/niriss/niriss_sensitivity_imaging.py
+++ b/tests/niriss/niriss_sensitivity_imaging.py
@@ -29,7 +29,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'nisrapid',
+              'readout_pattern': 'nisrapid',
               'ngroup': 93,
               'nint': 1,
               'nexp': 10

--- a/tests/niriss/niriss_sensitivity_soss.py
+++ b/tests/niriss/niriss_sensitivity_soss.py
@@ -4,7 +4,7 @@ from verification_tools import calc_limits
 
 configs = [{'aperture':'soss','filter':None,'disperser':'gr700xd'},
            {'aperture':'soss','filter':None,'disperser':'gr700xd'}]
-     
+
 apertures = np.array([2.5,2.5])*0.0656
 idt_fluxes = np.array([0.03, 0.03])
 orders = [1,2]
@@ -17,7 +17,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'substrip256',
-              'readmode': 'nisrapid',
+              'readout_pattern': 'nisrapid',
               'ngroup': 36,
               'nint': 1,
               'nexp': 5
@@ -26,7 +26,7 @@ strategy = {
             'method': 'soss',
             'order': 1
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=20,nflx=10,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12',orders=orders)
 

--- a/tests/niriss/niriss_sensitivity_wfss.py
+++ b/tests/niriss/niriss_sensitivity_wfss.py
@@ -3,12 +3,12 @@ import astropy.io.fits as fits
 from verification_tools import calc_limits
 
 configs = [{'aperture':'imager','filter':'f090w','disperser':'gr150r','bounds':(0.8,0.989)},
-           {'aperture':'imager','filter':'f115w','disperser':'gr150r','bounds':(1.021,1.268)}, 
+           {'aperture':'imager','filter':'f115w','disperser':'gr150r','bounds':(1.021,1.268)},
            {'aperture':'imager','filter':'f140m','disperser':'gr150r','bounds':(1.346,1.465)},
            {'aperture':'imager','filter':'f150w','disperser':'gr150r','bounds':(1.346,1.653)},
            {'aperture':'imager','filter':'f158m','disperser':'gr150r','bounds':(1.506,1.667)},
            {'aperture':'imager','filter':'f200w','disperser':'gr150r','bounds':(1.772,2.207)}]
-     
+
 apertures = np.array([1.5,1.5,1.5,1.5,1.5,1.5])*0.0656
 idt_fluxes = np.array([2e-4, 2e-4,2e-4,2e-4,2e-4,2e-4])
 skyfacs = [2,2,2,2,2,2]
@@ -21,7 +21,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'nis',
+              'readout_pattern': 'nis',
               'ngroup': 23,
               'nint': 1,
               'nexp': 10
@@ -32,7 +32,7 @@ strategy = {
             'sky_annulus': [0.16,0.5],
             'background_subtraction': False
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=15,skyfacs=skyfacs,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 

--- a/tests/nirspec/nirspec_sensitivity_fs.py
+++ b/tests/nirspec/nirspec_sensitivity_fs.py
@@ -33,7 +33,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'nrsirs2',
+              'readout_pattern': 'nrsirs2',
               'ngroup': 14,
               'nint': 1,
               'nexp': 10

--- a/tests/nirspec/nirspec_sensitivity_ifu.py
+++ b/tests/nirspec/nirspec_sensitivity_ifu.py
@@ -15,7 +15,7 @@ configs = [{'filter':'f070lp','disperser':'g140h'},
            {'filter':'f170lp','disperser':'g235m'},
            {'filter':'f290lp','disperser':'g395m'},
            {'filter':'clear','disperser':'prism'}]
-     
+
 #apertures = np.array([0.1*1.7,0.1*1.7,0.1*1.7])
 #idt_fluxes = np.array([1e-4,5e-3,1e-3])
 #skyfacs = np.array([1.,1.,1.])
@@ -31,7 +31,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'nrsirs2',
+              'readout_pattern': 'nrsirs2',
               'ngroup': 17,
               'nint': 1,
               'nexp': 4
@@ -41,7 +41,7 @@ strategy = {
             'aperture_size': 0.15,
             'dithers': [{'x':0,'y':0},{'x':1,'y':1}]
            }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=15,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 

--- a/tests/nirspec/nirspec_sensitivity_msa.py
+++ b/tests/nirspec/nirspec_sensitivity_msa.py
@@ -15,7 +15,7 @@ configs = [{'filter':'f070lp','disperser':'g140h'},
            {'filter':'f170lp','disperser':'g235m'},
            {'filter':'f290lp','disperser':'g395m'},
            {'filter':'clear','disperser':'prism'}]
-     
+
 #apertures = np.array([0.21,0.21])
 #idt_fluxes = np.array([1e-4,1e-3])
 apertures = np.array([0.21,0.21,0.21,0.21,0.21,0.21,0.21,0.21,0.21])
@@ -32,7 +32,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'nrsirs2',
+              'readout_pattern': 'nrsirs2',
               'ngroup': 14,
               'nint': 1,
               'nexp': 10
@@ -45,7 +45,7 @@ strategy = {
                          'on_source': [False,True,False]}
                        ]
             }
-    
+
 output = calc_limits.calc_limits(configs,apertures,idt_fluxes,obsmode=obsmode,scanfac=15,
                                  exp_config=exp_config,strategy=strategy,background='minzodi12')
 

--- a/tests/wfirstimager/wfirstimager_sensitivity_grism.py
+++ b/tests/wfirstimager/wfirstimager_sensitivity_grism.py
@@ -17,7 +17,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'deep8',
+              'readout_pattern': 'deep8',
               'ngroup': 5,
               'nint': 1,
               'nexp': 10

--- a/tests/wfirstimager/wfirstimager_sensitivity_imager.py
+++ b/tests/wfirstimager/wfirstimager_sensitivity_imager.py
@@ -32,7 +32,7 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'full',
-              'readmode': 'deep8',
+              'readout_pattern': 'deep8',
               'ngroup': 5,
               'nint': 1,
               'nexp': 10


### PR DESCRIPTION
This is work we promised via a deprecation warning in v1.3.1 and v1.4.

This PR contains changes to the verification tools to change "readmode" to "readout_pattern" everywhere necessary.

See companion Code PR [#4733](https://github.com/spacetelescope/pandeia/pull/4733), Data PR [#420](https://github.com/spacetelescope/pandeia_data/pull/420), and Test PR [#866](https://github.com/spacetelescope/pandeia_test/pull/866)
  
  
Describe **expected behavior changes**, including steps to reproduce:
Ultimately, nothing should behave differently, the one keyword will be different internally.

Update to manual test checklist required? Y/N
N

Test run link:
(no tests)

Manual testing performed:
(pending)

Addresses #  JETC-266
