### PR TITLE
TP12 changes: np.int and np.float are deprecated

### DIFF
--- a/verification_tools/compare_sensitivity.py
+++ b/verification_tools/compare_sensitivity.py
@@ -293,7 +293,7 @@ for instruments in insnames:
 
     instrument = instruments.split(',')[0]
     # Now that we know how many subplots we need, make a grid with enough plots.
-    ax = np.atleast_2d(fig.subplots(nrows=np.int(np.ceil(subplots/3.)),ncols=3))
+    ax = np.atleast_2d(fig.subplots(nrows=np.int32(np.ceil(subplots/3.)),ncols=3))
     # This sets up the legend and the color scheme based on the instrument
     scalarMap,legendhandles,ax = setup(instrument,ax)
 


### PR DESCRIPTION
This PR fixes some of the numpy-related deprecation warnings in TP12, mostly for the engine. All are related to np.int and np.float being deprecated (in favor of int() and float(), or bit-depth-aware functions)

Test run link(s):

Manual testing performed:

Addresses #