### PR TITLE
JETC-1117: Remove future and the word input

### DIFF
--- a/verification_tools/calc_backgrounds.py
+++ b/verification_tools/calc_backgrounds.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import numpy as np
 import scipy.interpolate as ip
@@ -68,7 +66,7 @@ def calc_backgrounds(configs, obsmode=None,
 
         scene = [source]
     
-        input = {
+        calc_input = {
             'scene': scene,
             'background': background,
             'configuration': {'instrument': obsmode,
@@ -76,7 +74,7 @@ def calc_backgrounds(configs, obsmode=None,
             'strategy': strategy
         }  
     
-        report = perform_calculation(input, dict_report=False)
+        report = perform_calculation(calc_input, dict_report=False)
 
         if report.bg_pix.shape[0] != report.bg_pix.shape[1]:
             bg_pix_rate = np.max(report.bg_pix,axis=0)

--- a/verification_tools/calc_limits.py
+++ b/verification_tools/calc_limits.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import numpy as np
 import scipy.interpolate as ip
@@ -208,7 +206,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
 
             source['spectrum']['normalization']['norm_flux'] = flux
 
-            input = {
+            calc_input = {
                 'scene': scene,
                 'background': background,
                 'configuration': {'instrument': obsmode,
@@ -216,7 +214,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
                 'strategy': strategy
             }
 
-            report = perform_calculation(input, dict_report=False)
+            report = perform_calculation(calc_input, dict_report=False)
             bg_pix_rate = np.min(report.bg_pix)
             aperture_source_rate = report.curves['extracted_flux'][1]
             aperture_bg_rate = report.curves['extracted_flux_plus_bg'][1][0]-aperture_source_rate[0]
@@ -255,7 +253,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
         #just need one to calculate the rate per mJy for the saturation estimate.
         source['spectrum']['normalization']['norm_flux'] = lim_flx[midpoint]
 
-        input = {
+        calc_input = {
             'scene': [source],
             'background': background,
             'configuration': {'instrument': obsmode,
@@ -263,7 +261,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
             'strategy': strategy
         }
 
-        report = perform_calculation(input, dict_report=False)
+        report = perform_calculation(calc_input, dict_report=False)
         fits_dict = report.as_fits()
         rep_dict = report.as_dict()
 

--- a/verification_tools/calc_limits_extended.py
+++ b/verification_tools/calc_limits_extended.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import numpy as np
 import scipy.interpolate as ip
@@ -198,7 +196,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
 
             source['spectrum']['normalization']['norm_flux'] = flux
 
-            input = {
+            calc_input = {
                 'scene': scene,
                 'background': background,
                 'configuration': {'instrument': obsmode,
@@ -206,7 +204,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
                 'strategy': strategy
             }
 
-            report = perform_calculation(input, dict_report=False)
+            report = perform_calculation(calc_input, dict_report=False)
             bg_pix_rate = np.min(report.bg_pix)
             aperture_source_rate = report.curves['extracted_flux'][1]
             aperture_bg_rate = report.curves['extracted_flux_plus_bg'][1][0]-aperture_source_rate[0]
@@ -240,7 +238,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
         #just need one to calculate the rate per mJy for the saturation estimate.
         source['spectrum']['normalization']['norm_flux'] = lim_flx[midpoint]
 
-        input = {
+        calc_input = {
             'scene': [source],
             'background': background,
             'configuration': {'instrument': obsmode,
@@ -248,7 +246,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=10, obsmode=None,
             'strategy': strategy
         }
 
-        report = perform_calculation(input, dict_report=False)
+        report = perform_calculation(calc_input, dict_report=False)
         fits_dict = report.as_fits()
         res_dict = report.as_dict()
 

--- a/verification_tools/compare_sensitivity.py
+++ b/verification_tools/compare_sensitivity.py
@@ -3,8 +3,6 @@ Properties that can be read out of plot_sensitivity:
 'wavelengths', 'sns', 'lim_fluxes', 'sat_limits'
 'line_limits' is also available for miri lrs and mrs
 """
-from __future__ import division
-import sys
 import glob
 import numpy as np
 from scipy import interpolate as interp


### PR DESCRIPTION
"future" imports are no longer necessary for our code. And the word "input" is now part of the baseutils standard library module, so we shouldn't use it as a variable.