### PR TITLE
JETC-3936: Fix the sensitivity plots for Roman

### DIFF
--- a/tests/wfi/wfi_sensitivity_imaging.py
+++ b/tests/wfi/wfi_sensitivity_imaging.py
@@ -32,10 +32,9 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'imaging',
-              'readout_pattern': 'rapid',
-              'ngroup': 184,
-              'nint': 18,
-              'nexp': 1
+              'ma_table_name': 'hltds_imaging1',
+              'nresultants': -1,
+              'nexp': 62
               }
 strategy = {
             'method': 'imagingapphot',

--- a/tests/wfi/wfi_sensitivity_spectroscopy.py
+++ b/tests/wfi/wfi_sensitivity_spectroscopy.py
@@ -17,10 +17,9 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'spectroscopy',
-              'readout_pattern': 'rapid',
-              'ngroup': 123,
-              'nint': 20,
-              'nexp': 1
+              'ma_table_name': 'hlwas_spectroscopy',
+              'nresultants': -1,
+              'nexp': 54
               }
 strategy = {
             'target_xy': [0.0, 0.0],

--- a/verification_tools/calc_limits.py
+++ b/verification_tools/calc_limits.py
@@ -275,9 +275,9 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
         aperture_bg_rate = aperture_total_rate-aperture_source_rate
         fov_source_rate = report.curves['total_flux'][1]
 
-        tgroup = report.signal.current_instrument.the_detector.exposure_spec.tgroup
+        #tgroup = report.signal.current_instrument.the_detector.exposure_spec.tgroup
         tframe =  report.signal.current_instrument.the_detector.exposure_spec.tframe
-        tfffr = report.signal.current_instrument.the_detector.exposure_spec.tfffr
+        #tfffr = report.signal.current_instrument.the_detector.exposure_spec.tfffr
         #det_type = report.signal.current_instrument.detector.exposure_spec.det_type
 
         # SOSS is rotated by 90 degrees on the detector, for some reason
@@ -300,10 +300,15 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
             excess=0
 
         # The regular output case
-        if obsmode['instrument'] != 'miri':
-            mintime = 2 * tframe
-        else:
+        if obsmode['instrument'] == 'miri':
             mintime = 5 * tframe #minimum recommended frames is 5 for MIRI
+        elif obsmode['instrument'] == 'wfi':
+            if obsmode['mode'] == "spectroscopy":
+                mintime = 16 * tframe # the shortest valid spec exposure is HLWAS_SPECTROSCOPY, nresultants=2
+            else:
+                mintime = 3 * tframe # The shortest valid exposure is DEFOCUS_MOD/DEFOCUS_LRG, nresultants=2
+        else:
+            mintime = 2 * tframe
 
         if excess==0:
             fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix)
@@ -330,7 +335,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
 
         # Calculate line sensitivities, assuming unresolved lines.
         if lim_flx.shape[0]>1:
-            if "lrsslit" in obsmode["mode"]:
+            if "lrsslit" in obsmode["mode"]: # covers both lrsslit and lrsslitless
                 sat_limit = np.min(sat_limit_detector,1)
             else:
                 sat_limit = np.min(sat_limit_detector,0)


### PR DESCRIPTION
I have fixed up the test configurations myself, going through and figuring out which combination of `3.04 or 4.03 * total number of frames in MA table * integer number of exposures` gets us closest to 10,000 seconds for both modes. (if and when the MA Table list changes in the PRD, we'll want to redo that check)

And then, I've gone through the code to set up special cases for Roman where necessary (and commenting out the tgroup and tfffr values that were actually unused!)

Ultimately, the sensitivity plot code now runs, and in sufficient time that we'll be able to generate plots for the 3.3 release (Roman Int)