### PR TITLE
JETC-5162: Ingest Rev. F MA Tables

### DIFF
--- a/tests/wfi/wfi_sensitivity_imaging.py
+++ b/tests/wfi/wfi_sensitivity_imaging.py
@@ -64,9 +64,9 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'imaging',
-              'ma_table_name': 'c2f_img_hlwas',
+              'ma_table_name': 'c2d_img_hlwas',
               'nresultants': -1,
-              'nexp': 16
+              'nexp': 25
               }
 strategy = {
             'method': 'imagingapphot',

--- a/tests/wfi/wfi_sensitivity_spectroscopy.py
+++ b/tests/wfi/wfi_sensitivity_spectroscopy.py
@@ -50,9 +50,9 @@ obsmode = {
            }
 exp_config = {
               'subarray': 'spectroscopy',
-              'ma_table_name': 'c3b_spec_hlss',
+              'ma_table_name': 'c3f_spec_hlss',
               'nresultants': -1,
-              'nexp': 26
+              'nexp': 10
               }
 strategy = {
             'target_xy': [0.0, 0.0],

--- a/verification_tools/roman_10000s.py
+++ b/verification_tools/roman_10000s.py
@@ -14,19 +14,19 @@ del ma_tables["diagnostic"]
 imag_tables = []
 spec_tables = []
 
-print("Best 10,000 second setups\n--------------------")
+print("Best 10,000 second setups\n          MA Table         #      nexp\n--------------------")
 
 for ma_table in ma_tables:
     for res, time in enumerate(ma_tables[ma_table]['integration_duration']):
         remainders = 10000/time
         
         if "wim" in ma_tables[ma_table]["observing_mode"]:
-            imag_tables.append([f"{ma_table}_{res+ma_tables[ma_table]['num_pre_science_resultants']}", remainders])
+            imag_tables.append([ma_table, res+ma_tables[ma_table]['num_pre_science_resultants'], remainders])
         elif "wsm" in ma_tables[ma_table]["observing_mode"]:
-            spec_tables.append([f"{ma_table}_{res+ma_tables[ma_table]['num_pre_science_resultants']}", remainders])
+            spec_tables.append([ma_table, res+ma_tables[ma_table]['num_pre_science_resultants'], remainders])
 
-print("Imaging:", sorted(imag_tables, key=(lambda a: a[1] % 1))[0])
-print("Spec:\t", sorted(spec_tables, key=(lambda a: a[1] % 1))[0])
+print("Imaging:", sorted(imag_tables, key=(lambda a: a[2] % 1))[0])
+print("Spec:\t", sorted(spec_tables, key=(lambda a: a[2] % 1))[0])
 
 print("--------------------\n Or for full tables:\n--------------------")
 
@@ -38,9 +38,9 @@ for ma_table in ma_tables:
     remainders = 10000/time
     
     if "wim" in ma_tables[ma_table]["observing_mode"]:
-        imag_tables.append([f"{ma_table}_-1", remainders])
+        imag_tables.append([ma_table, -1, remainders])
     elif "wsm" in ma_tables[ma_table]["observing_mode"]:
-        spec_tables.append([f"{ma_table}_-1", remainders])
+        spec_tables.append([ma_table, -1, remainders])
 
-print("Imaging:", sorted(imag_tables, key=(lambda a: a[1] % 1))[0])
-print("Spec:\t", sorted(spec_tables, key=(lambda a: a[1] % 1))[0])
+print("Imaging:", sorted(imag_tables, key=(lambda a: a[2] % 1))[0])
+print("Spec:\t", sorted(spec_tables, key=(lambda a: a[2] % 1))[0])

--- a/verification_tools/roman_10000s.py
+++ b/verification_tools/roman_10000s.py
@@ -1,0 +1,46 @@
+import os, json
+pandeia_data = os.environ["pandeia_refdata"]
+
+INST= "wfi"
+
+with open(f"{pandeia_data}/roman/{INST}/config.json") as configfile:
+    config_data = json.load(configfile)
+
+ma_tables = config_data["readout_pattern_config"]
+
+del ma_tables["meta"]
+del ma_tables["diagnostic"]
+
+imag_tables = []
+spec_tables = []
+
+print("Best 10,000 second setups\n--------------------")
+
+for ma_table in ma_tables:
+    for res, time in enumerate(ma_tables[ma_table]['integration_duration']):
+        remainders = 10000/time
+        
+        if "wim" in ma_tables[ma_table]["observing_mode"]:
+            imag_tables.append([f"{ma_table}_{res+ma_tables[ma_table]['num_pre_science_resultants']}", remainders])
+        elif "wsm" in ma_tables[ma_table]["observing_mode"]:
+            spec_tables.append([f"{ma_table}_{res+ma_tables[ma_table]['num_pre_science_resultants']}", remainders])
+
+print("Imaging:", sorted(imag_tables, key=(lambda a: a[1] % 1))[0])
+print("Spec:\t", sorted(spec_tables, key=(lambda a: a[1] % 1))[0])
+
+print("--------------------\n Or for full tables:\n--------------------")
+
+imag_tables = []
+spec_tables = []
+
+for ma_table in ma_tables:
+    time = ma_tables[ma_table]['integration_duration'][-1]
+    remainders = 10000/time
+    
+    if "wim" in ma_tables[ma_table]["observing_mode"]:
+        imag_tables.append([f"{ma_table}_-1", remainders])
+    elif "wsm" in ma_tables[ma_table]["observing_mode"]:
+        spec_tables.append([f"{ma_table}_-1", remainders])
+
+print("Imaging:", sorted(imag_tables, key=(lambda a: a[1] % 1))[0])
+print("Spec:\t", sorted(spec_tables, key=(lambda a: a[1] % 1))[0])

--- a/verification_tools/roman_10000s.py
+++ b/verification_tools/roman_10000s.py
@@ -25,8 +25,8 @@ for ma_table in ma_tables:
         elif "wsm" in ma_tables[ma_table]["observing_mode"]:
             spec_tables.append([ma_table, res+ma_tables[ma_table]['num_pre_science_resultants'], remainders])
 
-print("Imaging:", sorted(imag_tables, key=(lambda a: a[2] % 1))[0])
-print("Spec:\t", sorted(spec_tables, key=(lambda a: a[2] % 1))[0])
+print("Imaging:", sorted(imag_tables, key=(lambda a: abs(a[2] - round(a[2]))))[0])
+print("Spec:\t", sorted(spec_tables, key=(lambda a: abs(a[2] - round(a[2]))))[0])
 
 print("--------------------\n Or for full tables:\n--------------------")
 
@@ -42,5 +42,5 @@ for ma_table in ma_tables:
     elif "wsm" in ma_tables[ma_table]["observing_mode"]:
         spec_tables.append([ma_table, -1, remainders])
 
-print("Imaging:", sorted(imag_tables, key=(lambda a: a[2] % 1))[0])
-print("Spec:\t", sorted(spec_tables, key=(lambda a: a[2] % 1))[0])
+print("Imaging:", sorted(imag_tables, key=(lambda a: abs(a[2] - round(a[2]))))[0])
+print("Spec:\t", sorted(spec_tables, key=(lambda a: abs(a[2] - round(a[2]))))[0])


### PR DESCRIPTION
This PR updates the sensitivity plots for the Rev. F MA tables, by finding the new best instrument setups.

Here, I define "best" solely as "closest to 10,000 seconds", and because all of the Roman MA tables aren't long enough, I wrote a script, `roman_10000s.py` to find the ones that would be the closest to 10000s with an integer number of exposures. An example output from the program is below:

```
Best 10,000 second setups
          MA Table         #      nexp
--------------------
Imaging: ['c2c_img_hlwas', 14, 34.00091292451202]
Spec:	 ['c3f_spec_hlss', 9, 24.01341773729489]
--------------------
 Or for full tables:
--------------------
Imaging: ['c2d_img_hlwas', -1, 25.09591218458485]
Spec:	 ['c3f_spec_hlss', -1, 10.026220873615305]
```

In discussions with RTB I've heard that they're going to discourage people from truncating the tables, so I've opted to use full tables (the lower set of results)

Code PR: https://github.com/spacetelescope/pandeia/pull/6319
Data PR: https://github.com/spacetelescope/pandeia_data/pull/1071
Test PR: https://github.com/spacetelescope/pandeia_test/pull/1916