### PR TITLE
Add MIRI LRS subarrays (JETC-6484)

### DIFF
--- a/tests/miri/miri_sensitivity_lrs.py
+++ b/tests/miri/miri_sensitivity_lrs.py
@@ -1,10 +1,13 @@
 import numpy as np
 from verification_tools import calc_limits
 
-configs = [{'aperture':'imager','mode':'lrsslitless'},
-           {'aperture':'lrsslit','mode':'lrsslit'}]
-apertures = np.array([0.84,0.84])*7.5/10.
-idt_fluxes = np.array([5e-3,30e-3])
+configs = [{'aperture':'imager','mode':'lrsslitless','subarray':'slitlessprism'},
+           {'aperture':'imager','mode':'lrsslitless','subarray':'slitlessprism_ip'},
+           {'aperture':'imager','mode':'lrsslitless','subarray':'slitlessprism_ips'},
+           {'aperture':'lrsslit','mode':'lrsslit','subarray':'full'},
+           {'aperture':'lrsslit','mode':'lrsslit','subarray':'subslit'}]
+apertures = np.array([0.84,0.84,0.84,0.84,0.84])*7.5/10.
+idt_fluxes = np.array([5e-3,5e-3,5e-3,30e-3,30e-3])
 
 obsmode = {
            'instrument': 'miri',

--- a/verification_tools/calc_limits.py
+++ b/verification_tools/calc_limits.py
@@ -322,7 +322,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
             mintime = 2 * tframe
 
         if excess==0:
-            fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix)
+            fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix)
             rate_per_mjy = report.signal.rate/lim_flx[midpoint]
             if "miri" in obsmode["instrument"] and (("lrsslit" in obsmode["mode"]) or ("wfss" in obsmode["mode"])):
                 bg_pix_rate_min = np.min(report.bg_pix,1)
@@ -337,17 +337,17 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
             if "miri" in obsmode["instrument"] and (("lrsslit" in obsmode["mode"]) or ("wfss" in obsmode["mode"])):
                 bg_pix_rate_min = np.min(report.bg_pix[int(excess/2):-int(excess/2),:])
                 bg_pix_rate_max = np.max(report.bg_pix[int(excess/2):-int(excess/2),:])
-                fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
+                fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
                 rate_per_mjy = report.signal.rate[int(excess/2):-int(excess/2)-1,:]/lim_flx[midpoint]
             elif "wfi" in obsmode["instrument"] and ("spectroscopy" in obsmode["mode"]):
                 bg_pix_rate_min = np.min(report.bg_pix[int(excess/2):-int(excess/2),:])
                 bg_pix_rate_max = np.max(report.bg_pix[int(excess/2):-int(excess/2),:])
-                fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
+                fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
                 rate_per_mjy = report.signal.rate[int(excess/2):-int(excess/2)-1,:]/lim_flx[midpoint]
             else:
                 bg_pix_rate_min = np.min(report.bg_pix[:,int(excess/2):-int(excess/2)])
                 bg_pix_rate_max = np.max(report.bg_pix[:,int(excess/2):-int(excess/2)])
-                fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix[:,int(excess/2):-int(excess/2)-1])
+                fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix[:,int(excess/2):-int(excess/2)-1])
                 rate_per_mjy = report.signal.rate[:,int(excess/2):-int(excess/2)-1]/lim_flx[midpoint]
 
         sat_limit_detector = fullwell_minus_bg/mintime/np.abs(rate_per_mjy) #units of mJy
@@ -395,7 +395,7 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
         # And now, recompute for the ngroups=1 case
         mintime = 1 * tframe
         if excess==0:
-            fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix)
+            fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix)
             rate_per_mjy = report.signal.rate/lim_flx[midpoint]
             if "miri" in obsmode["instrument"] and (("lrsslit" in obsmode["mode"]) or ("wfss" in obsmode["mode"])):
                 bg_pix_rate_min = np.min(report.bg_pix,1)
@@ -410,17 +410,17 @@ def calc_limits(configs, apertures, fluxes, scanfac=100, obsmode=None,
             if "miri" in obsmode["instrument"] and (("lrsslit" in obsmode["mode"]) or ("wfss" in obsmode["mode"])):
                 bg_pix_rate_min = np.min(report.bg_pix[int(excess/2):-int(excess/2),:])
                 bg_pix_rate_max = np.max(report.bg_pix[int(excess/2):-int(excess/2),:])
-                fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
+                fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
                 rate_per_mjy = report.signal.rate[int(excess/2):-int(excess/2)-1,:]/lim_flx[midpoint]
             elif "wfi" in obsmode["instrument"] and "spectroscopy" in obsmode["mode"]:
                 bg_pix_rate_min = np.min(report.bg_pix[int(excess/2):-int(excess/2),:])
                 bg_pix_rate_max = np.max(report.bg_pix[int(excess/2):-int(excess/2),:])
-                fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
+                fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix[int(excess/2):-int(excess/2)-1,:])
                 rate_per_mjy = report.signal.rate[int(excess/2):-int(excess/2)-1,:]/lim_flx[midpoint]
             else:
                 bg_pix_rate_min = np.min(report.bg_pix[:,int(excess/2):-int(excess/2)])
                 bg_pix_rate_max = np.max(report.bg_pix[:,int(excess/2):-int(excess/2)])
-                fullwell_minus_bg = (report.signal.the_detector.fullwell-mintime*report.bg_pix[:,int(excess/2):-int(excess/2)-1])
+                fullwell_minus_bg = (report.signal.the_detector.saturation_fullwell-mintime*report.bg_pix[:,int(excess/2):-int(excess/2)-1])
                 rate_per_mjy = report.signal.rate[:,int(excess/2):-int(excess/2)-1]/lim_flx[midpoint]
 
         sat_limit_detector = fullwell_minus_bg/mintime/np.abs(rate_per_mjy) #units of mJy

--- a/verification_tools/compare_sensitivity.py
+++ b/verification_tools/compare_sensitivity.py
@@ -143,6 +143,7 @@ def gettext(data,x):
             textval = data['configs'][x]['filter']
         else:
             textval = data['configs'][x]['aperture']
+
     return textval
 
 def compareone(data1, data2, x, ax, scalarMap):
@@ -199,6 +200,7 @@ def comparemulti(data1, data2, x, ax, scalarMap, instrument, mode):
     flux1 = fun1(wave)
     flux2 = fun2(wave)
     textval = gettext(data1,x)
+
     if 'bounds' in keys.keys():
         bounds = data1['configs'][x]['bounds']
         gsubs = np.where((wave>bounds[0]) & (wave<bounds[1]))
@@ -208,6 +210,11 @@ def comparemulti(data1, data2, x, ax, scalarMap, instrument, mode):
         else:
             gsubs = np.where(flux1 > -6)
     ax.plot(wave, (flux1-flux2)/flux1*100, color='#000000', linewidth=3)
+    if instrument == 'miri' and mode == 'lrs':
+        # MIRI LRS wants the subarray listed as well.  If this becomes a general request,
+        #  consider modifying the gettext method.
+        textval += ' ' + data1['configs'][x]['subarray']
+
     ax.set_title("{} {} {}".format(instrument.upper(), mode.upper(), textval.upper()))
 
     return ax, wave_wide

--- a/verification_tools/compare_sensitivity.py
+++ b/verification_tools/compare_sensitivity.py
@@ -143,7 +143,6 @@ def gettext(data,x):
             textval = data['configs'][x]['filter']
         else:
             textval = data['configs'][x]['aperture']
-
     return textval
 
 def compareone(data1, data2, x, ax, scalarMap):
@@ -200,7 +199,6 @@ def comparemulti(data1, data2, x, ax, scalarMap, instrument, mode):
     flux1 = fun1(wave)
     flux2 = fun2(wave)
     textval = gettext(data1,x)
-
     if 'bounds' in keys.keys():
         bounds = data1['configs'][x]['bounds']
         gsubs = np.where((wave>bounds[0]) & (wave<bounds[1]))


### PR DESCRIPTION
Added the new subarrays for MIRI LRS calcs.  This involved updating the configurations in the MIRI LRS tests, and then updating compare_sensitivity to add the subarray name for MIRI LRS plots.  The plots below are comparing the same data to itself (hence the lack of changes), but it does show that it will generate labeled plots for the subarrays.

<img width="2000" height="2000" alt="miri_outputs_outputs_lim_fluxes" src="https://github.com/user-attachments/assets/f924c5d8-9c07-422c-a765-24b6ac5fbe7f" />
